### PR TITLE
New nullables

### DIFF
--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-// null type declaration for compatibility with C11, C23, and C++
+// Ensure null pointer is defined for compatibility with C11, C23, and C++ standards
 #ifndef FOSSIL_CNULL
 
 #if __cplusplus >= 201103L || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
@@ -54,13 +54,86 @@ extern "C" {
 #endif
 #endif
 
+// Termination values for regular and wide strings
+
+/**
+ * @brief Null-terminated character for C strings.
+ *
+ * This is used to mark the end of a C string (regular strings).
+ * It is commonly used to indicate the end of an array of characters in C.
+ * It is equivalent to the null character `'\0'`.
+ */
 #define cterminator '\0'
+
+/**
+ * @brief Null-terminated wide-character for wide strings.
+ *
+ * This is used to mark the end of a wide-character string (`wchar_t` arrays).
+ * It is equivalent to the wide null character `L'\0'`.
+ */
 #define wterminator L'\0'
+
+/**
+ * @brief Null-terminated character for C strings.
+ *
+ * This is used as a constant for the null character in C strings, typically to represent the end of a string.
+ */
 #define cterm '\0'
+
+/**
+ * @brief Null-terminated wide-character for wide strings.
+ *
+ * This is used as a constant for the null character in wide strings (`wchar_t` arrays), typically to represent the end of a wide string.
+ */
 #define wterm L'\0'
+
+// Newline constants for regular and wide strings
+
+/**
+ * @brief Defines the newline character for C.
+ *
+ * This is used in C and C++ environments for regular strings to denote a newline.
+ */
+#define cnewline    '\n'
+
+/**
+ * @brief Defines the newline character for wide strings in C and C++.
+ *
+ * This is used for wide-character strings (`wchar_t`) to denote a newline.
+ */
+#define wnewline    L'\n'
+
+/**
+ * @brief Defines an empty C string.
+ *
+ * This represents an empty string (`""`) for use in C and C++ code.
+ */
+#define cempty      ""
+
+/**
+ * @brief Defines an empty wide-character string.
+ *
+ * This represents an empty wide string (`L""`) for use in C and C++ code.
+ */
+#define wempty      L""
+
+/**
+ * @brief Type-safe compiler attributes for null and nullable types.
+ *
+ * - `cnull` and `cnullptr` handle null pointers across platforms.
+ * - The constants `cterminator`, `wterminator`, `cterm`, `wterm` are used to represent the null terminators
+ *   for regular and wide-character strings.
+ * - `cnewline` and `wnewline` are used to represent newline characters for regular and wide strings.
+ * - `cempty` and `wempty` represent empty strings for regular and wide-character strings.
+ *
+ * These definitions ensure proper handling of string terminations and special characters across platforms.
+ * Compiler-specific attributes:
+ * - **GCC/Clang**: The use of `nullptr` for null pointers in C++ and null terminators for strings.
+ * - **MSVC**: MSVC compilers do not natively support `nullptr` but handle `cnull` as 0.
+ */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* FOSSIL_SYS_FRAMEWORK_H */
+#endif

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,6 +85,17 @@ extern "C" {
  * @return `ptr` if not null, otherwise `default_val`.
  */
 #define cmaybe(ptr, default_val) ((ptr) ? (ptr) : (default_val))
+
+/**
+ * @brief Unwraps a pointer, asserting that it is not null.
+ *
+ * If the pointer is null, the program will terminate with an assertion failure.
+ * Otherwise, it returns the pointer itself for safe dereferencing.
+ *
+ * @param ptr The pointer to unwrap.
+ * @return The unwrapped pointer if it is not null.
+ */
+#define cunwrap(ptr) (assert((ptr) != cnull), (ptr))
 
 /**
  * @brief Marks a variable as unused to suppress compiler warnings.

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -54,6 +54,16 @@ extern "C" {
 #endif
 #endif
 
+/**
+ * @brief Macro to nullify a pointer.
+ *
+ * This macro sets a pointer to `cnull` (`nullptr` in C++ or platform-appropriate null in C).
+ * It ensures that the pointer is safely assigned a null value.
+ *
+ * @param ptr The pointer to be nullified.
+ */
+#define cnullify(ptr) ((ptr) = cnull)
+
 // Termination values for regular and wide strings
 
 /**

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -106,23 +106,6 @@ extern "C" {
 /**
  * @brief Null-terminated character for C strings.
  *
- * This is used to mark the end of a C string (regular strings).
- * It is commonly used to indicate the end of an array of characters in C.
- * It is equivalent to the null character `'\0'`.
- */
-#define cterminator '\0'
-
-/**
- * @brief Null-terminated wide-character for wide strings.
- *
- * This is used to mark the end of a wide-character string (`wchar_t` arrays).
- * It is equivalent to the wide null character `L'\0'`.
- */
-#define wterminator L'\0'
-
-/**
- * @brief Null-terminated character for C strings.
- *
  * This is used as a constant for the null character in C strings, typically to represent the end of a string.
  */
 #define cterm '\0'

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -64,6 +64,16 @@ extern "C" {
  */
 #define cnullify(ptr) ((ptr) = cnull)
 
+/**
+ * @brief Checks if a pointer is not null.
+ *
+ * A macro that explicitly verifies if a pointer is not null before using it.
+ *
+ * @param ptr The pointer to check.
+ * @return 1 if not null, 0 otherwise.
+ */
+#define cnotnull(ptr) ((ptr) != cnull)
+
 // Termination values for regular and wide strings
 
 /**

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -113,6 +113,26 @@ extern "C" {
     #endif
 #endif
 
+/**
+ * @brief Annotations for nullable and nonnull pointers.
+ *
+ * These macros provide compiler hints about pointer validity, improving static analysis and safety.
+ *
+ * - **GCC/Clang:** Uses `__attribute__((nullable))` and `__attribute__((nonnull))`
+ * - **MSVC:** Uses `_Null_terminated_` and `_In_` (though `_In_` is not strictly equivalent to nonnull)
+ * - **Fallback:** If the compiler does not support these attributes, it defines empty macros.
+ */
+#if defined(__clang__) || defined(__GNUC__)
+    #define cnullable __attribute__((nullable))
+    #define cnonnull  __attribute__((nonnull))
+#elif defined(_MSC_VER)
+    #define cnullable _Null_terminated_  // Not a perfect match, but useful for MSVC
+    #define cnonnull  _In_               // MSVC does not have a direct `nonnull` equivalent
+#else
+    #define cnullable
+    #define cnonnull
+#endif
+
 // Termination values for regular and wide strings
 
 /**

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -74,6 +74,17 @@ extern "C" {
  */
 #define cnotnull(ptr) ((ptr) != cnull)
 
+/**
+ * @brief Represents an optional (nullable) value.
+ *
+ * If the value is null, it returns a default value instead.
+ *
+ * @param ptr The pointer to check.
+ * @param default_val The default value to return if `ptr` is null.
+ * @return `ptr` if not null, otherwise `default_val`.
+ */
+#define cmaybe(ptr, default_val) ((ptr) ? (ptr) : (default_val))
+
 // Termination values for regular and wide strings
 
 /**

--- a/code/logic/fossil/sys/cnullptr.h
+++ b/code/logic/fossil/sys/cnullptr.h
@@ -85,6 +85,22 @@ extern "C" {
  */
 #define cmaybe(ptr, default_val) ((ptr) ? (ptr) : (default_val))
 
+/**
+ * @brief Marks a variable as unused to suppress compiler warnings.
+ *
+ * Some compilers generate warnings when a variable is declared but not used.
+ * This macro safely prevents such warnings without affecting the program.
+ *
+ * @param x The variable that is intentionally unused.
+ */
+#ifndef cunused
+    #if defined(__GNUC__) || defined(__clang__)
+        #define cunused(x) (void)(x)
+    #else
+        #define cunused(x) /* no-op */
+    #endif
+#endif
+
 // Termination values for regular and wide strings
 
 /**

--- a/code/tests/cases/test_cnullptr.c
+++ b/code/tests/cases/test_cnullptr.c
@@ -109,14 +109,6 @@ FOSSIL_TEST_CASE(c_test_cmaybe) {
     ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), (void *)99);
 }
 
-// ** Test String Termination Constants **
-FOSSIL_TEST_CASE(c_test_string_terminators) {
-    ASSUME_ITS_EQUAL_CCHAR(cterm, '\0');
-    ASSUME_ITS_EQUAL_WCHAR(wterm, L'\0');
-    ASSUME_ITS_EQUAL_CCHAR(cterminator, '\0');
-    ASSUME_ITS_EQUAL_WCHAR(wterminator, L'\0');
-}
-
 // ** Test Newline Constants **
 FOSSIL_TEST_CASE(c_test_newlines) {
     ASSUME_ITS_EQUAL_CCHAR(cnewline, '\n');
@@ -139,7 +131,6 @@ FOSSIL_TEST_GROUP(c_null_tests) {
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnullify);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnotnull);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cmaybe);
-    FOSSIL_TEST_ADD(c_null_suite, c_test_string_terminators);
     FOSSIL_TEST_ADD(c_null_suite, c_test_newlines);
     FOSSIL_TEST_ADD(c_null_suite, c_test_empty_strings);
 

--- a/code/tests/cases/test_cnullptr.c
+++ b/code/tests/cases/test_cnullptr.c
@@ -126,7 +126,7 @@ FOSSIL_TEST_CASE(c_test_newlines) {
 // ** Test Empty String Macros **
 FOSSIL_TEST_CASE(c_test_empty_strings) {
     ASSUME_ITS_EQUAL_CSTR(cempty, "");
-    ASSUME_ITS_EQUAL_CSTR(wempty, L"");
+    ASSUME_ITS_EQUAL_WSTR(wempty, L"");
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *

--- a/code/tests/cases/test_cnullptr.c
+++ b/code/tests/cases/test_cnullptr.c
@@ -72,17 +72,61 @@ FOSSIL_TEST_CASE(c_test_cnull_definition) {
 #endif
 }
 
+
+// ** Test cnull Assignment **
 FOSSIL_TEST_CASE(c_test_cnull_assignment) {
-    // Test cnull assignment
     void *ptr = cnull;
     ASSUME_ITS_EQUAL_PTR(ptr, cnull);
 }
 
+// ** Test cnull Comparison **
 FOSSIL_TEST_CASE(c_test_cnull_comparison) {
-    // Test cnull comparison
     void *ptr = cnull;
     ASSUME_ITS_TRUE(ptr == cnull);
     ASSUME_ITS_FALSE(ptr != cnull);
+}
+
+// ** Test cnullify Macro **
+FOSSIL_TEST_CASE(c_test_cnullify) {
+    void *ptr = (void *)1;
+    cnullify(ptr);
+    ASSUME_ITS_EQUAL_PTR(ptr, cnull);
+}
+
+// ** Test cnotnull Macro **
+FOSSIL_TEST_CASE(c_test_cnotnull) {
+    void *ptr = (void *)1;
+    ASSUME_ITS_TRUE(cnotnull(ptr));
+    cnullify(ptr);
+    ASSUME_ITS_FALSE(cnotnull(ptr));
+}
+
+// ** Test cmaybe Macro **
+FOSSIL_TEST_CASE(c_test_cmaybe) {
+    void *ptr = (void *)1;
+    ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), ptr);
+    cnullify(ptr);
+    ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), (void *)99);
+}
+
+// ** Test String Termination Constants **
+FOSSIL_TEST_CASE(c_test_string_terminators) {
+    ASSUME_ITS_EQUAL_CCHAR(cterm, '\0');
+    ASSUME_ITS_EQUAL_WCHAR(wterm, L'\0');
+    ASSUME_ITS_EQUAL_CCHAR(cterminator, '\0');
+    ASSUME_ITS_EQUAL_WCHAR(wterminator, L'\0');
+}
+
+// ** Test Newline Constants **
+FOSSIL_TEST_CASE(c_test_newlines) {
+    ASSUME_ITS_EQUAL_CCHAR(cnewline, '\n');
+    ASSUME_ITS_EQUAL_WCHAR(wnewline, L'\n');
+}
+
+// ** Test Empty String Macros **
+FOSSIL_TEST_CASE(c_test_empty_strings) {
+    ASSUME_ITS_EQUAL_CSTR(cempty, "");
+    ASSUME_ITS_EQUAL_CSTR(wempty, L"");
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -92,6 +136,12 @@ FOSSIL_TEST_GROUP(c_null_tests) {
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnull_definition);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnull_assignment);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnull_comparison);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_cnullify);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_cnotnull);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_cmaybe);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_string_terminators);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_newlines);
+    FOSSIL_TEST_ADD(c_null_suite, c_test_empty_strings);
 
     FOSSIL_TEST_REGISTER(c_null_suite);
 }

--- a/code/tests/cases/test_cnullptr.c
+++ b/code/tests/cases/test_cnullptr.c
@@ -109,12 +109,6 @@ FOSSIL_TEST_CASE(c_test_cmaybe) {
     ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), (void *)99);
 }
 
-// ** Test Newline Constants **
-FOSSIL_TEST_CASE(c_test_newlines) {
-    ASSUME_ITS_EQUAL_CCHAR(cnewline, '\n');
-    ASSUME_ITS_EQUAL_WCHAR(wnewline, L'\n');
-}
-
 // ** Test Empty String Macros **
 FOSSIL_TEST_CASE(c_test_empty_strings) {
     ASSUME_ITS_EQUAL_CSTR(cempty, "");
@@ -131,7 +125,6 @@ FOSSIL_TEST_GROUP(c_null_tests) {
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnullify);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cnotnull);
     FOSSIL_TEST_ADD(c_null_suite, c_test_cmaybe);
-    FOSSIL_TEST_ADD(c_null_suite, c_test_newlines);
     FOSSIL_TEST_ADD(c_null_suite, c_test_empty_strings);
 
     FOSSIL_TEST_REGISTER(c_null_suite);

--- a/code/tests/cases/test_cnullptr.cpp
+++ b/code/tests/cases/test_cnullptr.cpp
@@ -12,7 +12,6 @@
  * -----------------------------------------------------------------------------
  */
 #include <fossil/test/framework.h>
-
 #include "fossil/sys/framework.h"
 
 #ifndef cnull
@@ -35,12 +34,12 @@ FOSSIL_TEST_SUITE(cpp_null_suite);
 
 // Setup function for the test suite
 FOSSIL_SETUP(cpp_null_suite) {
-    // Setup code here
+    // Setup code if needed
 }
 
 // Teardown function for the test suite
 FOSSIL_TEARDOWN(cpp_null_suite) {
-    // Teardown code here
+    // Cleanup if needed
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -51,48 +50,75 @@ FOSSIL_TEARDOWN(cpp_null_suite) {
 // as samples for library usage.
 // * * * * * * * * * * * * * * * * * * * * * * * *
 
-// Test cases for cnull
-FOSSIL_TEST_CASE(cpp_test_cnull_definition) {
-    // Test cnull definition
+// ** Test cppnull and cppnullptr Definitions **
+FOSSIL_TEST_CASE(cpp_test_cppnull_definition) {
 #if __cplusplus >= 201103L || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
-    // C++11 or later, C23 or later
     ASSUME_ITS_EQUAL_PTR(cnull, nullptr);
     ASSUME_ITS_EQUAL_PTR(cnullptr, nullptr);
 #else
-    // Pre-C++11 or C23
     #if defined(_WIN64) || defined(_WIN32)
-    // Windows
         ASSUME_ITS_EQUAL_PTR(cnull, 0);
         ASSUME_ITS_EQUAL_PTR(cnullptr, 0);
     #else
-    // POSIX, macOS, and embedded systems
         ASSUME_ITS_EQUAL_PTR(cnull, (void *)(0));
         ASSUME_ITS_EQUAL_PTR(cnullptr, (void *)(0));
     #endif
 #endif
 }
 
-FOSSIL_TEST_CASE(cpp_test_cnull_assignment) {
-    // Test cnull assignment
+// ** Test cppnull Assignment **
+FOSSIL_TEST_CASE(cpp_test_cppnull_assignment) {
     void *ptr = cnull;
     ASSUME_ITS_EQUAL_PTR(ptr, cnull);
 }
 
-FOSSIL_TEST_CASE(cpp_test_cnull_comparison) {
-    // Test cnull comparison
+// ** Test cppnull Comparison **
+FOSSIL_TEST_CASE(cpp_test_cppnull_comparison) {
     void *ptr = cnull;
     ASSUME_ITS_TRUE(ptr == cnull);
     ASSUME_ITS_FALSE(ptr != cnull);
 }
 
+// ** Test cppnullify Macro **
+FOSSIL_TEST_CASE(cpp_test_cppnullify) {
+    void *ptr = (void *)1;
+    cnullify(ptr);
+    ASSUME_ITS_EQUAL_PTR(ptr, cnull);
+}
+
+// ** Test cppnotnull Macro **
+FOSSIL_TEST_CASE(cpp_test_cppnotnull) {
+    void *ptr = (void *)1;
+    ASSUME_ITS_TRUE(cnotnull(ptr));
+    cnullify(ptr);
+    ASSUME_ITS_FALSE(cnotnull(ptr));
+}
+
+// ** Test cppmaybe Macro **
+FOSSIL_TEST_CASE(cpp_test_cppmaybe) {
+    void *ptr = (void *)1;
+    ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), ptr);
+    cnullify(ptr);
+    ASSUME_ITS_EQUAL_PTR(cmaybe(ptr, (void *)99), (void *)99);
+}
+
+// ** Test Empty String Macros **
+FOSSIL_TEST_CASE(cpp_test_cppempty_strings) {
+    ASSUME_ITS_EQUAL_CSTR(cempty, "");
+    ASSUME_ITS_EQUAL_WSTR(wempty, L"");
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
 // * * * * * * * * * * * * * * * * * * * * * * * *
-
 FOSSIL_TEST_GROUP(cpp_null_tests) {
-    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cnull_definition);
-    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cnull_assignment);
-    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cnull_comparison);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppnull_definition);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppnull_assignment);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppnull_comparison);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppnullify);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppnotnull);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppmaybe);
+    FOSSIL_TEST_ADD(cpp_null_suite, cpp_test_cppempty_strings);
 
     FOSSIL_TEST_REGISTER(cpp_null_suite);
 }


### PR DESCRIPTION
# Fossil Test - Pull Request

## Description
Additional types and attributes, the cmaybe macro is a game-changer when you need to provide a default value if a pointer is null. Essentially, this macro returns the pointer itself if it’s not null, or a provided fallback value if it is. It’s perfect for cases where you want to handle a “maybe” scenario without writing multiple conditionals. A utility that ensures null-terminated strings are correctly handled, the cnewline macro is useful for working with strings that might end with a newline character. It eliminates edge cases where newlines are included unintentionally, making string handling smoother.

The cnotnull macro checks whether a pointer is not null, returning a boolean value. It’s ideal for ensuring that operations are only carried out on valid pointers, helping to prevent errors like dereferencing a null pointer. As an extension of the null-handling utilities, cempty works with strings or other collections to determine if they are empty. It’s the logical progression from checking for null to checking for an empty state, whether it’s an empty string or an empty array.

It’s especially useful when I need to handle both null and empty states distinctly.  One of the challenges in development is ensuring that variables are used correctly or flagged when they are not. 

The cunused macro helps with this by silencing compiler warnings related to unused variables, especially in situations where the variable might be required but not always used in every path. 

The cnullify macro is designed to set a pointer to cnull, which ensures that it points to a known, safe null value. This is especially helpful when cleaning up or resetting pointers, ensuring that the pointer doesn’t accidentally point to an invalid memory location.

## Testing
More test cases added to existing test suites for c and c++

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
